### PR TITLE
Reverse animation direction of ribbon component

### DIFF
--- a/src/components/ribbon/index.astro
+++ b/src/components/ribbon/index.astro
@@ -13,11 +13,11 @@
 <style scoped>
     @keyframes Marquee {
         0% {
-            transform: translateX(-50%);
+            transform: translateX(0%);
         }
 
         100% {
-            transform: translateX(0%);
+            transform: translateX(-50%);
         }
     }
 


### PR DESCRIPTION
Reverse the direction of the `Marquee` keyframes animation in the `src/components/ribbon/index.astro` file.

* Change the `Marquee` keyframes animation to animate the ribbon from `translateX(0%)` to `translateX(-50%)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rycont/binary-honam?shareId=87075562-1ee3-416b-a929-9766a26a7efa).